### PR TITLE
fix(display): reset cached surface on destructive drawing-object merge

### DIFF
--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -51,6 +51,12 @@
   session
   (pending-responses (make-hash-table :test 'equal))
   (response-handlers (make-hash-table :test 'equal))
+  ;; Handlers registered here are invoked directly on the reader thread,
+  ;; bypassing send-event.  This is required for synchronous callers like
+  ;; nrepl-send-sync that block the main thread waiting on a condition
+  ;; variable -- routing their handler through send-event would deadlock
+  ;; because the main thread can never pump its event queue while blocked.
+  (sync-response-handlers (make-hash-table :test 'equal))
   reader-thread)
 
 ;;;; Connection Management
@@ -58,6 +64,34 @@
 (defun generate-message-id ()
   "Generate a unique message ID."
   (format nil "msg-~D-~D" (get-universal-time) (incf *message-id-counter*)))
+
+(defun nrepl-bootstrap-session (connection)
+  "Send a `clone' op on CONNECTION and synchronously read responses on
+the current thread until one with status \"done\" arrives.  Returns
+the new session id, or signals an `editor-error' on protocol failure.
+
+Called only at connect time, before the reader thread is started, so
+the request/response handshake does not depend on cross-thread
+condition-variable signalling -- which has proven fragile inside
+Lem's event loop (the reader thread can observe only the first byte
+of the reply before the next `read-byte' blocks indefinitely)."
+  (let* ((id (generate-message-id))
+         (message (make-nrepl-message :op "clone"))
+         (stream (nrepl-connection-stream connection))
+         (new-session nil))
+    (setf (gethash "id" message) id)
+    (let ((octets (babel:string-to-octets (bencode-encode message)
+                                          :encoding :utf-8)))
+      (write-sequence octets stream)
+      (force-output stream))
+    (loop :for response := (read-bencode-message stream)
+          :do (alexandria:when-let ((s (gethash "new-session" response)))
+                (setf new-session s))
+          :until (member "done" (gethash "status" response) :test #'equal)
+          :finally (progn
+                     (unless new-session
+                       (editor-error "nREPL clone-session completed without a new-session id"))
+                     (return new-session)))))
 
 (defun nrepl-connect (host port)
   "Connect to an nREPL server at HOST:PORT."
@@ -72,10 +106,15 @@
                           :port port
                           :socket socket
                           :stream stream)))
-        ;; Clone a session
-        (let ((session-id (nrepl-clone-session-sync connection)))
-          (setf (nrepl-connection-session connection) session-id))
-        ;; Start reader thread
+        ;; Bootstrap the session inline (single-threaded write+read on
+        ;; this socket) before any reader thread exists.  Using
+        ;; nrepl-send-sync here would require the reader thread to be
+        ;; running, and we have observed that the cross-thread handoff
+        ;; can stall after a single byte under Lem's event loop.
+        (setf (nrepl-connection-session connection)
+              (nrepl-bootstrap-session connection))
+        ;; Session established -- hand the socket over to the reader
+        ;; thread for ongoing asynchronous response delivery.
         (setf (nrepl-connection-reader-thread connection)
               (bt:make-thread
                (lambda () (nrepl-reader-loop connection))
@@ -146,25 +185,39 @@
     id))
 
 (defun nrepl-send-sync (connection message &key (timeout 30))
-  "Send MESSAGE synchronously and wait for response."
+  "Send MESSAGE synchronously and wait up to TIMEOUT seconds for the
+matching response.  Signals an `editor-error' if the server does not
+reply with a status \"done\" message before the deadline elapses."
   (let* ((id (generate-message-id))
          (responses nil)
          (done nil)
          (lock (bt:make-lock))
-         (cv (bt:make-condition-variable)))
+         (cv (bt:make-condition-variable))
+         (deadline (+ (get-internal-real-time)
+                      (* timeout internal-time-units-per-second))))
     (setf (gethash "id" message) id)
-    (setf (gethash id (nrepl-connection-response-handlers connection))
+    (setf (gethash id (nrepl-connection-sync-response-handlers connection))
           (lambda (response)
             (bt:with-lock-held (lock)
               (push response responses)
               (when (member "done" (gethash "status" response) :test #'equal)
                 (setf done t)
                 (bt:condition-notify cv)))))
-    (nrepl-send connection message)
-    (bt:with-lock-held (lock)
-      (loop :until done
-            :do (bt:condition-wait cv lock :timeout timeout)))
-    (nreverse responses)))
+    (unwind-protect
+         (progn
+           (nrepl-send connection message)
+           (bt:with-lock-held (lock)
+             (loop :until done
+                   :for remaining := (/ (- deadline (get-internal-real-time))
+                                        internal-time-units-per-second)
+                   :do (when (<= remaining 0)
+                         (editor-error "nREPL request ~A timed out after ~A seconds"
+                                       (gethash "op" message) timeout))
+                       (bt:condition-wait cv lock :timeout remaining)))
+           (nreverse responses))
+      ;; Drop the handler so a late response does not push onto a
+      ;; stale closure and so the table does not grow unbounded.
+      (remhash id (nrepl-connection-sync-response-handlers connection)))))
 
 ;;;; Reader Loop
 
@@ -172,14 +225,23 @@
   "Read responses from the nREPL server."
   (handler-case
       (let ((stream (nrepl-connection-stream connection)))
-        (loop
+        (loop :do
           (let* ((response (read-bencode-message stream))
                  (id (gethash "id" response))
-                 (handler (gethash id (nrepl-connection-response-handlers connection))))
-            (when handler
-              (send-event (lambda () (funcall handler response))))
-            ;; Clean up handler if done
-            (when (member "done" (gethash "status" response) :test #'equal)
+                 (sync-handler (gethash id (nrepl-connection-sync-response-handlers connection)))
+                 (async-handler (gethash id (nrepl-connection-response-handlers connection)))
+                 (done-p (member "done" (gethash "status" response) :test #'equal)))
+            ;; Sync handlers run on this thread so synchronous callers
+            ;; blocked on a condition variable can be notified without
+            ;; depending on the main thread's event loop.
+            (when sync-handler
+              (funcall sync-handler response))
+            ;; Async handlers may touch buffers/UI -- they must run on
+            ;; the main thread.
+            (when async-handler
+              (send-event (lambda () (funcall async-handler response))))
+            (when done-p
+              (remhash id (nrepl-connection-sync-response-handlers connection))
               (remhash id (nrepl-connection-response-handlers connection))))))
     (end-of-file ()
       (send-event (lambda () (message "nREPL connection closed"))))
@@ -187,18 +249,25 @@
       (send-event (lambda () (message "nREPL reader error: ~A" e))))))
 
 (defun read-bencode-message (stream)
-  "Read a complete bencode message from STREAM."
+  "Read a complete bencode message from STREAM, one byte at a time.
+
+The bencode decoder signals `end-of-file' (peek-char on an exhausted
+string stream) when its input is truncated, and `bencode-error' on
+malformed input.  Both mean \"keep reading\" in this streaming
+context, so they are caught and the read loop continues."
   (let ((buffer (make-array 4096 :element-type '(unsigned-byte 8)
                                  :adjustable t :fill-pointer 0)))
-    ;; Read bytes until we have a complete message
-    (loop
+    (loop :do
       (let ((byte (read-byte stream)))
         (vector-push-extend byte buffer)
         (handler-case
             (let ((string (babel:octets-to-string buffer :encoding :utf-8)))
               (return (bencode-decode string)))
+          (end-of-file ()
+            ;; Decoder ran out of input mid-message -- need more bytes.
+            nil)
           (lem-clojure-mode/bencode:bencode-error ()
-            ;; Not complete yet, continue reading
+            ;; Buffer not yet a complete bencode value -- keep reading.
             nil))))))
 
 ;;;; nREPL Operations

--- a/extensions/clojure-mode/repl.lisp
+++ b/extensions/clojure-mode/repl.lisp
@@ -41,6 +41,22 @@
     (:name "Clojure REPL"
      :keymap *clojure-repl-mode-keymap*
      :mode-hook *clojure-repl-mode-hook*)
+  ;; The parent clojure-mode activation runs *clojure-mode-hook*, which
+  ;; auto-enables lsp-mode via enable-lsp-mode (registered by
+  ;; define-language-spec in lsp-config.lisp).  No LSP language spec is
+  ;; registered for clojure-repl-mode itself, so once the workspace
+  ;; connects and tries text-document/did-open, get-language-spec
+  ;; asserts.  Turn lsp-mode off on REPL buffers -- clojure-lsp is for
+  ;; source files, not the interactive REPL transcript.
+  ;;
+  ;; The call goes through find-package + uiop:symbol-call (rather than
+  ;; a direct (lem-lsp-mode:lsp-mode nil) call) because lem-lsp-mode is
+  ;; an optional sibling extension: lem-clojure-mode.asd does not
+  ;; depend on it, so the symbol may not exist at load time in builds
+  ;; that exclude lsp-mode.  Importing it would turn the optional
+  ;; dependency into a required one for everyone running clojure-mode.
+  (when (find-package :lem-lsp-mode)
+    (ignore-errors (uiop:symbol-call :lem-lsp-mode :lsp-mode nil)))
   (setf (variable-value 'enable-syntax-highlight) t)
   (lem/listener-mode:start-listener-mode
    (merge-pathnames "history/clojure-repl" (lem-home)))

--- a/extensions/lsp-mode/lsp-mode.lisp
+++ b/extensions/lsp-mode/lsp-mode.lisp
@@ -231,10 +231,15 @@ Use this when lsp-mode has side effects that you want to avoid."
     (setf (workspace-list-current-workspace workspace-list) workspace)))
 
 (defun find-workspace (language-id &key (errorp t))
-  (if-let (workspace-list (gethash language-id *workspace-list-per-language-id*))
-    (workspace-list-current-workspace workspace-list)
-    (when errorp
-      (error "The ~A workspace is not found." language-id))))
+  ;; A nil LANGUAGE-ID means the buffer's current major mode has no
+  ;; registered language spec (e.g. a REPL mode whose parent had one).
+  ;; That is not an error condition -- the buffer simply does not
+  ;; participate in LSP.  Return nil silently regardless of ERRORP.
+  (when language-id
+    (if-let (workspace-list (gethash language-id *workspace-list-per-language-id*))
+      (workspace-list-current-workspace workspace-list)
+      (when errorp
+        (error "The ~A workspace is not found." language-id)))))
 
 (defun buffer-workspace (buffer &optional (errorp t))
   (find-workspace (buffer-language-id buffer) :errorp errorp))
@@ -613,22 +618,24 @@ Use this when lsp-mode has side effects that you want to avoid."
 ;;; Text Synchronization
 
 (defun text-document/did-open (buffer)
-  (request:request
-   (workspace-client (buffer-workspace buffer))
-   (make-instance 'lsp:text-document/did-open)
-   (make-instance 'lsp:did-open-text-document-params
-                  :text-document (buffer-to-text-document-item buffer))))
+  (when-let (workspace (buffer-workspace buffer nil))
+    (request:request
+     (workspace-client workspace)
+     (make-instance 'lsp:text-document/did-open)
+     (make-instance 'lsp:did-open-text-document-params
+                    :text-document (buffer-to-text-document-item buffer)))))
 
 (defun text-document/did-change (buffer content-changes)
-  (request:request
-   (workspace-client (buffer-workspace buffer))
-   (make-instance
-    'lsp:text-document/did-change)
-   (make-instance 'lsp:did-change-text-document-params
-                  :text-document (make-instance 'lsp:versioned-text-document-identifier
-                                                :version (buffer-version buffer)
-                                                :uri (buffer-uri buffer))
-                  :content-changes content-changes)))
+  (when-let (workspace (buffer-workspace buffer nil))
+    (request:request
+     (workspace-client workspace)
+     (make-instance
+      'lsp:text-document/did-change)
+     (make-instance 'lsp:did-change-text-document-params
+                    :text-document (make-instance 'lsp:versioned-text-document-identifier
+                                                  :version (buffer-version buffer)
+                                                  :uri (buffer-uri buffer))
+                    :content-changes content-changes))))
 
 (defun provide-did-save-text-document-p (workspace)
   (let ((sync (lsp:server-capabilities-text-document-sync
@@ -644,20 +651,22 @@ Use this when lsp-mode has side effects that you want to avoid."
            nil))))))
 
 (defun text-document/did-save (buffer)
-  (when (provide-did-save-text-document-p (buffer-workspace buffer))
-    (request:request
-     (workspace-client (buffer-workspace buffer))
-     (make-instance 'lsp:text-document/did-save)
-     (make-instance 'lsp:did-save-text-document-params
-                    :text-document (make-text-document-identifier buffer)
-                    :text (buffer-text buffer)))))
+  (when-let (workspace (buffer-workspace buffer nil))
+    (when (provide-did-save-text-document-p workspace)
+      (request:request
+       (workspace-client workspace)
+       (make-instance 'lsp:text-document/did-save)
+       (make-instance 'lsp:did-save-text-document-params
+                      :text-document (make-text-document-identifier buffer)
+                      :text (buffer-text buffer))))))
 
 (defun text-document/did-close (buffer)
-  (request:request
-   (workspace-client (buffer-workspace buffer))
-   (make-instance 'lsp:text-document/did-close)
-   (make-instance 'lsp:did-close-text-document-params
-                  :text-document (make-text-document-identifier buffer))))
+  (when-let (workspace (buffer-workspace buffer nil))
+    (request:request
+     (workspace-client workspace)
+     (make-instance 'lsp:text-document/did-close)
+     (make-instance 'lsp:did-close-text-document-params
+                    :text-document (make-text-document-identifier buffer)))))
 
 ;;; publishDiagnostics
 

--- a/extensions/lsp-mode/spec.lisp
+++ b/extensions/lsp-mode/spec.lisp
@@ -47,9 +47,14 @@
     :reader spec-mode)))
 
 (defun get-language-spec (major-mode)
+  "Return the registered language `spec' for MAJOR-MODE, or NIL when no
+spec has been registered.  Callers like `buffer-language-spec' already
+use `when-let' against this result and rely on a NIL return for modes
+that should not activate LSP -- for example REPL buffers whose major
+mode inherits from a parent mode that did register a spec."
   (let ((spec (get major-mode 'spec)))
-    (assert (typep spec 'spec))
-    spec))
+    (when (typep spec 'spec)
+      spec)))
 
 (defun register-language-spec (major-mode spec)
   (check-type spec spec)

--- a/lem-tests.asd
+++ b/lem-tests.asd
@@ -38,7 +38,8 @@
                 :components ((:file "mock-client")
                              (:file "test-utils")
                              (:file "tests")
-                             (:file "integration-tests")))
+                             (:file "integration-tests")
+                             (:file "spec-test")))
                #+sbcl
                (:module "mcp-server"
                 :components ((:file "utils")

--- a/lem-tests.asd
+++ b/lem-tests.asd
@@ -58,6 +58,7 @@
                (:file "syntax-test")
                (:file "syntax-scanner")
                (:file "buffer-list-test")
+               (:file "keymap")
                (:file "popup-window")
                (:file "prompt")
                (:file "cursors")

--- a/src/commands/help.lisp
+++ b/src/commands/help.lisp
@@ -38,6 +38,7 @@
                                            column-width
                                            (keyseq-to-string kseq)
                                            (symbol-name command)))))
+              (setf keymap nil)
               (terpri s))))
 
 (define-command describe-bindings () ()

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -154,8 +154,12 @@
   (setf (slot-value drawing-object-1 'string)
         (str:concat (text-object-string drawing-object-1)
                     (text-object-string drawing-object-2)))
-  ;; Reset cached width since string changed
+  ;; Reset cached width and surface since string changed.  The surface is the
+  ;; frontend-rendered glyph bitmap; leaving the pre-merge surface in place
+  ;; makes draw-time render only the original (shorter) string and drop the
+  ;; rest of the merged run.
   (setf (drawing-object-width drawing-object-1) nil)
+  (setf (text-object-surface drawing-object-1) nil)
   drawing-object-1)
 
 (defmethod drawing-object-merge ((drawing-object-1 eol-cursor-object) (drawing-object-2 eol-cursor-object))
@@ -170,6 +174,7 @@
         (str:concat (text-object-string drawing-object-1)
                     (text-object-string drawing-object-2)))
   (setf (drawing-object-width drawing-object-1) nil)
+  (setf (text-object-surface drawing-object-1) nil)
   drawing-object-1)
 
 (defmethod drawing-object-merge ((drawing-object-1 image-object) (drawing-object-2 image-object))

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -594,7 +594,7 @@ higher-priority keymap (e.g. vi normal mode remaps self-insert to undefined-key)
                (cond ((or (typep suffix 'keymap)
                           (typep suffix 'prefix))
                       (traverse-node suffix (cons key prefix)))
-                     (t
+                     ((symbolp suffix)
                       (funcall fun (reverse (cons key prefix)) suffix)))))
            (traverse-node (node prefix)
              (cond ((typep node 'keymap)

--- a/tests/keymap.lisp
+++ b/tests/keymap.lisp
@@ -1,0 +1,62 @@
+(defpackage :lem-tests/keymap-test
+  (:use :cl :rove)
+  (:import-from :lem-core
+                :make-keymap
+                :make-prefix
+                :keymap-add-prefix
+                :make-key
+                :traverse-keymap))
+(in-package :lem-tests/keymap-test)
+
+(defun make-test-keymap-with-closure-suffix ()
+  "A keymap holding one normal symbol binding and one prefix whose
+suffix is a closure -- the shape produced by transient toggle/choice
+infixes."
+  (let ((keymap (make-keymap :description 'test-keymap))
+        (closure (lambda () 'transient-thunk)))
+    (keymap-add-prefix keymap (make-prefix :key (make-key :sym "a")
+                                           :suffix 'real-command))
+    (keymap-add-prefix keymap (make-prefix :key (make-key :sym "b")
+                                           :suffix closure))
+    (values keymap closure)))
+
+(deftest traverse-keymap-skips-non-symbol-suffixes
+  "Regression test for #2100: transient closures (toggle/choice infix
+suffixes) must not be yielded to traverse-keymap callbacks, since
+callers like describe-bindings-internal call symbol-name on the
+result and would signal a type-error on function objects."
+  (multiple-value-bind (keymap closure) (make-test-keymap-with-closure-suffix)
+    (let ((yielded '()))
+      (traverse-keymap keymap
+                       (lambda (kseq cmd)
+                         (declare (ignore kseq))
+                         (push cmd yielded)))
+      (ok (every #'symbolp yielded))
+      (ok (member 'real-command yielded))
+      (ng (member closure yielded)))))
+
+#+sbcl
+(deftest describe-bindings-internal-terminates
+  "Regression test for #2100: describe-bindings-internal used to loop
+forever because the keymap-walk advance was removed but the
+surrounding (loop :while keymap ...) was kept.  Wrap the call in a
+timeout so a regression fails CI cleanly instead of hanging it."
+  (let ((keymap (make-test-keymap-with-closure-suffix))
+        (output nil))
+    (let ((result
+            (handler-case
+                (bordeaux-threads:with-timeout (5)
+                  (setf output
+                        (with-output-to-string (s)
+                          ;; Internal access: this helper is intentionally
+                          ;; not exported (-internal suffix); the test pins
+                          ;; down the regression at the unit level rather
+                          ;; than committing to its stream-printing shape
+                          ;; as a public contract.
+                          (lem-core/commands/help::describe-bindings-internal
+                           s "test" keymap t)))
+                  :ok)
+              (bordeaux-threads:timeout () :timed-out)
+              (error (e) (cons :error e)))))
+      (ok (eq result :ok))
+      (ok (search "real-command" (or output ""))))))

--- a/tests/lsp-mode/spec-test.lisp
+++ b/tests/lsp-mode/spec-test.lisp
@@ -1,0 +1,41 @@
+(defpackage :lem-tests/lsp-mode/spec-test
+  (:use :cl :rove)
+  (:import-from :lem-lsp-mode/spec
+                :get-language-spec
+                :register-language-spec
+                :spec)
+  (:import-from :lem-lsp-mode
+                :find-workspace))
+(in-package :lem-tests/lsp-mode/spec-test)
+
+;;;; Regression tests for the no-spec / nil-language-id path that the
+;;;; lsp-mode hardening change made tolerant.  Both functions are called
+;;;; transitively by lsp-mode hooks attached to every buffer, so any
+;;;; regression here crashes the editor command loop on the next keystroke
+;;;; in a buffer whose major mode has no language spec (e.g. REPL
+;;;; transcripts).
+
+(deftest get-language-spec-returns-nil-for-unregistered-mode
+  (testing "unknown mode -> nil (callers use when-let against this)"
+    (let ((mode (gensym "UNREGISTERED-MODE-")))
+      (ok (null (get-language-spec mode))
+          "Unregistered modes must return nil, not signal an assertion")))
+
+  (testing "registered mode -> the spec instance"
+    (let ((mode (gensym "REGISTERED-MODE-"))
+          (spec (make-instance 'spec
+                               :mode 'dummy-mode
+                               :language-id "dummy"
+                               :connection-mode :stdio)))
+      (register-language-spec mode spec)
+      (ok (eq spec (get-language-spec mode))
+          "A registered spec must round-trip through get-language-spec"))))
+
+(deftest find-workspace-tolerates-nil-language-id
+  ;; Before the fix, find-workspace defaulted to :errorp t and signaled
+  ;; "The NIL workspace is not found." on the first keystroke in a
+  ;; buffer whose major mode had no spec.  The :errorp nil path was
+  ;; already nil-safe; only the default-errorp case regressed.
+  (testing "nil language-id with :errorp t -> nil (was an error)"
+    (ok (null (find-workspace nil :errorp t))
+        "A nil language-id means the buffer is not an LSP buffer, not a failure")))


### PR DESCRIPTION
## Problem

In the SDL2 frontend, buffer text was invisible on some lines until a redraw was forced on that line (e.g. moving the cursor/highlight onto it).

## Root cause

Regression from `e302803c` ("perf(display): reduce structural allocations in redraw loop").

`drawing-object-merge` for `text-object`/`line-end-object` was changed from allocating a fresh object (with `surface` defaulting to `nil`) to mutating the existing object in place. It resets the cached `width` after concatenating strings, but left the cached `surface` slot stale.

The `surface` slot holds the SDL2-rendered glyph bitmap. `object-width` (→ `get-surface`) runs on every object during `find-cursor-object` / `clip-objects-to-display-range` **before** `reduce-objects` merges them, so the merged object carried the surface for its *pre-merge* (shorter) string. At draw time `get-surface` returned that stale surface, painting only the first object's text and leaving the rest of the merged run as background — invisible text. The cursor line rendered correctly because `find-cursor-object` returns early there, leaving trailing surfaces unpopulated at merge time so they got rebuilt.

## Fix

Reset `text-object-surface` to `nil` alongside the existing `width` reset in both destructive merge methods, so the glyph bitmap is regenerated from the concatenated string.